### PR TITLE
Removed and replaced classic setters and getters with lombok annotatations

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -64,5 +64,10 @@
             <artifactId>Java-WebSocket</artifactId>
             <version>1.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>RELEASE</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/p2p/solanaj/serum/Order.java
+++ b/src/main/java/org/p2p/solanaj/serum/Order.java
@@ -1,5 +1,6 @@
 package org.p2p.solanaj.serum;
 
+import lombok.*;
 import org.p2p.solanaj.core.PublicKey;
 
 import java.security.SecureRandom;
@@ -7,6 +8,9 @@ import java.security.SecureRandom;
 /**
  * Class that represents a Serum order.
  */
+@Builder
+@Getter
+@Setter(AccessLevel.PACKAGE)
 public class Order {
 
     private long price;
@@ -22,116 +26,6 @@ public class Order {
     private OrderTypeLayout orderTypeLayout;
     private SelfTradeBehaviorLayout selfTradeBehaviorLayout;
     private boolean buy;
-
-    public Order(float floatPrice, float floatQuantity) {
-        this.floatPrice = floatPrice;
-        this.floatQuantity = floatQuantity;
-        this.clientOrderId = new SecureRandom().nextLong();
-    }
-
-    // constructor used by new orders
-    public Order(float floatPrice, float floatQuantity, long clientOrderId) {
-        this.floatPrice = floatPrice;
-        this.floatQuantity = floatQuantity;
-        this.clientOrderId = clientOrderId;
-    }
-
-    public Order(long price, long quantity, long clientOrderId, float floatPrice, float floatQuantity, PublicKey owner) {
-        this.price = price;
-        this.quantity = quantity;
-        this.clientOrderId = clientOrderId;
-        this.floatPrice = floatPrice;
-        this.floatQuantity = floatQuantity;
-        this.owner = owner;
-    }
-
-    public long getPrice() {
-        return price;
-    }
-
-    public void setPrice(long price) {
-        this.price = price;
-    }
-
-    public long getQuantity() {
-        return quantity;
-    }
-
-    public void setQuantity(long quantity) {
-        this.quantity = quantity;
-    }
-
-    public long getClientOrderId() {
-        return clientOrderId;
-    }
-
-    public void setClientOrderId(long clientOrderId) {
-        this.clientOrderId = clientOrderId;
-    }
-
-    public float getFloatPrice() {
-        return floatPrice;
-    }
-
-    public void setFloatPrice(float floatPrice) {
-        this.floatPrice = floatPrice;
-    }
-
-    public float getFloatQuantity() {
-        return floatQuantity;
-    }
-
-    public void setFloatQuantity(float floatQuantity) {
-        this.floatQuantity = floatQuantity;
-    }
-
-    public PublicKey getOwner() {
-        return owner;
-    }
-
-    public void setOwner(PublicKey owner) {
-        this.owner = owner;
-    }
-
-    public long getMaxQuoteQuantity() {
-        return maxQuoteQuantity;
-    }
-
-    public void setMaxQuoteQuantity(long maxQuoteQuantity) {
-        this.maxQuoteQuantity = maxQuoteQuantity;
-    }
-
-    public long getClientId() {
-        return clientId;
-    }
-
-    public void setClientId(long clientId) {
-        this.clientId = clientId;
-    }
-
-    public OrderTypeLayout getOrderTypeLayout() {
-        return orderTypeLayout;
-    }
-
-    public void setOrderTypeLayout(OrderTypeLayout orderTypeLayout) {
-        this.orderTypeLayout = orderTypeLayout;
-    }
-
-    public SelfTradeBehaviorLayout getSelfTradeBehaviorLayout() {
-        return selfTradeBehaviorLayout;
-    }
-
-    public void setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout selfTradeBehaviorLayout) {
-        this.selfTradeBehaviorLayout = selfTradeBehaviorLayout;
-    }
-
-    public boolean isBuy() {
-        return buy;
-    }
-
-    public void setBuy(boolean buy) {
-        this.buy = buy;
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/org/p2p/solanaj/serum/OrderBook.java
+++ b/src/main/java/org/p2p/solanaj/serum/OrderBook.java
@@ -52,15 +52,14 @@ public class OrderBook {
         slab.getSlabNodes().forEach(slabNode -> {
             if (slabNode instanceof SlabLeafNode) {
                 SlabLeafNode slabLeafNode = (SlabLeafNode) slabNode;
-                orders.add(
-                        new Order(
-                                slabLeafNode.getPrice(),
-                                slabLeafNode.getQuantity(),
-                                slabLeafNode.getClientOrderId(),
-                                SerumUtils.priceLotsToNumber(slabLeafNode.getPrice(), baseDecimals, quoteDecimals, baseLotSize, quoteLotSize),
-                                (float) ((slabLeafNode.getQuantity() * baseLotSize) / SerumUtils.getBaseSplTokenMultiplier(baseDecimals)),
-                                slabLeafNode.getOwner()
-                        )
+                orders.add(Order.builder()
+                        .price(slabLeafNode.getPrice())
+                        .quantity(slabLeafNode.getQuantity())
+                        .clientOrderId(slabLeafNode.getClientOrderId())
+                        .floatPrice(SerumUtils.priceLotsToNumber(slabLeafNode.getPrice(), baseDecimals, quoteDecimals, baseLotSize, quoteLotSize))
+                        .floatQuantity((float) ((slabLeafNode.getQuantity() * baseLotSize) / SerumUtils.getBaseSplTokenMultiplier(baseDecimals)))
+                        .owner(slabLeafNode.getOwner())
+                        .build()
                 );
             }
         });

--- a/src/test/java/org/p2p/solanaj/core/OrderTest.java
+++ b/src/test/java/org/p2p/solanaj/core/OrderTest.java
@@ -64,15 +64,13 @@ public class OrderTest {
 
         long orderId = 11133711L;
 
-        final Order order = new Order(
-                1337,
-                0.1f,
-                orderId
-        );
-
-        order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setBuy(false);
+        final Order order = Order.builder()
+                .floatPrice(1337)
+                .floatQuantity(0.1f)
+                .clientOrderId(orderId)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(false).build();
 
         // Place order
         String transactionId = serumManager.placeOrder(
@@ -90,15 +88,13 @@ public class OrderTest {
 
         long usdcOrderId = 12321L;
 
-        final Order usdcOrder = new Order(
-                0.001f,
-                0.1f,
-                usdcOrderId
-        );
-
-        usdcOrder.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        usdcOrder.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        usdcOrder.setBuy(true);
+        final Order usdcOrder = Order.builder()
+                .floatPrice(0.001f)
+                .floatQuantity(0.1f)
+                .clientOrderId(usdcOrderId)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(true).build();
 
         // Place order
         String usdcTransactionId = serumManager.placeOrder(
@@ -310,15 +306,13 @@ public class OrderTest {
         long orderId = 11133711L;
 
         // 1 oxy bid @ $0.01
-        final Order order = new Order(
-                0.01f,
-                1f,
-                orderId
-        );
-
-        order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setBuy(true);
+        final Order order = Order.builder()
+                .floatPrice(0.01f)
+                .floatQuantity(1f)
+                .clientOrderId(orderId)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(true).build();
 
         // Place order
         String transactionId = serumManager.placeOrder(
@@ -397,15 +391,14 @@ public class OrderTest {
                 .build();
 
         long orderId = 11133711L;
-        final Order order = new Order(
-                0.20f,
-                0.01f,
-                orderId
-        );
 
-        order.setOrderTypeLayout(OrderTypeLayout.IOC);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setBuy(true);
+        final Order order = Order.builder()
+                .floatPrice(0.20f)
+                .floatQuantity(0.01f)
+                .clientOrderId(orderId)
+                .orderTypeLayout(OrderTypeLayout.IOC)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(true).build();
 
         // Place order
         String transactionId = serumManager.placeOrder(
@@ -449,15 +442,13 @@ public class OrderTest {
         long orderId = 11133711L;
 
         // 0.1 mer offer @ $1337
-        final Order order = new Order(
-                1337,
-                0.1f,
-                orderId
-        );
-
-        order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setBuy(false);
+        final Order order = Order.builder()
+                .floatPrice(1337)
+                .floatQuantity(0.1f)
+                .clientOrderId(orderId)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(false).build();
 
         // Place order
         String transactionId = serumManager.placeOrder(
@@ -537,16 +528,15 @@ public class OrderTest {
 
         long orderId = 11133711L;
 
-        // 0.1 mer offer @ $1337
-        final Order order = new Order(
-                1337,
-                0.1f,
-                orderId
-        );
 
-        order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setBuy(false);
+        // 0.1 mer offer @ $1337
+        final Order order = Order.builder()
+                .floatPrice(1337)
+                .floatQuantity(0.1f)
+                .clientOrderId(orderId)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(false).build();
 
         final OpenOrdersAccount openOrdersAccount = SerumUtils.findOpenOrdersAccountForOwner(
                 client,
@@ -626,14 +616,12 @@ public class OrderTest {
                 account.getPublicKey()
         );
 
-        final Order order = new Order(
-                0.01f,
-                1
-        );
-
-        order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setBuy(true);
+        final Order order = Order.builder()
+                .floatPrice(0.01f)
+                .floatQuantity(1)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(true).build();
 
         String transactionId = serumManager.placeOrder(
                 account,
@@ -695,13 +683,14 @@ public class OrderTest {
         Transaction transaction = new Transaction();
 
         for (int i = 1; i <= 9; i++) {
-            Order order = new Order(
-                    0.01F + (0.01f * 1/2 * i),
-                    10 - i
-            );
-            order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-            order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-            order.setBuy(true);
+            final Order order = Order.builder()
+                    .floatPrice(0.01F + (0.01f * 1 / 2 * i))
+                    .floatQuantity(10 - i)
+                    .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                    .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                    .buy(true)
+                    .build();
+
             serumManager.setOrderPrices(order, xrpBearUsdcMarket);
 
             transaction.addInstruction(
@@ -752,13 +741,14 @@ public class OrderTest {
         transaction = new Transaction();
 
         for (int i = 1; i <= 9; i++) {
-            Order order = new Order(
-                    0.01F + (0.01f * 1/2 * i),
-                    10 - i
-            );
-            order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-            order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-            order.setBuy(true);
+            final Order order = Order.builder()
+                    .floatPrice(0.01F + (0.01f * 1 / 2 * i))
+                    .floatQuantity(10 - i)
+                    .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                    .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                    .buy(true)
+                    .build();
+
             serumManager.setOrderPrices(order, xrpBearUsdcMarket);
 
             transaction.addInstruction(
@@ -826,10 +816,12 @@ public class OrderTest {
                 account.getPublicKey()
         );
 
-        Order order = new Order(0.1f, 1);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        order.setBuy(true);
+        final Order order = Order.builder()
+                .floatPrice(0.1f)
+                .floatQuantity(1)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .buy(true).build();
 
         String txId = serumManager.placeOrder(
                 account,
@@ -877,15 +869,14 @@ public class OrderTest {
             for (int i = 1; i <= 10; i++) {
                 long orderId = 10000L + i;
 
-                final Order order = new Order(
-                        0.01f * i,
-                        1,
-                        orderId
-                );
+                final Order order = Order.builder()
+                        .floatPrice(0.01f * i)
+                        .floatQuantity(1)
+                        .clientOrderId(orderId)
+                        .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                        .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                        .buy(true).build();
 
-                order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-                order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-                order.setBuy(true);
                 serumManager.setOrderPrices(order, xrpBearUsdcMarket);
 
                 transaction.addInstruction(
@@ -974,15 +965,13 @@ public class OrderTest {
         for (int i = 1; i <= 15; i++) {
             long orderId = 10000L + i;
 
-            final Order order = new Order(
-                    0.18f - (i * .001f),
-                    0.01f,
-                    orderId
-            );
-
-            order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-            order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-            order.setBuy(true);
+            final Order order = Order.builder()
+                    .floatPrice(0.18f - (i * .001f))
+                    .floatQuantity(0.01f)
+                    .clientOrderId(orderId)
+                    .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                    .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                    .buy(true).build();
 
             // Place order 1
             String transactionId = serumManager.placeOrder(
@@ -1050,15 +1039,13 @@ public class OrderTest {
         long orderId = 10000L;
 
         // 0.1 mer offer @ $1337
-        final Order order = new Order(
-                1000f,
-                0.1f,
-                orderId
-        );
-
-        order.setOrderTypeLayout(OrderTypeLayout.POST_ONLY);
-        order.setSelfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE);
-        order.setBuy(false);
+        final Order order = Order.builder()
+                .floatPrice(1000f)
+                .floatQuantity(0.1f)
+                .clientOrderId(orderId)
+                .orderTypeLayout(OrderTypeLayout.POST_ONLY)
+                .selfTradeBehaviorLayout(SelfTradeBehaviorLayout.DECREMENT_TAKE)
+                .buy(false).build();
 
         // Place order 1
         String transactionId = serumManager.placeOrder(


### PR DESCRIPTION
I slapped lombok on the Order class, removed the existing setters and getters and replaced them with the @Getter, @Setter and @Builder attributes.

I left the Setter simply because of the SerumManager.setOrderPrices function is called from inside the placeOrderInternal and I'm not sure whats the best way to restructure it. On the other hand I made these setters package private, forcing the consumer to use the Builder class.