### PR TITLE
feat: add getConfirmedBlock

### DIFF
--- a/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
+++ b/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
@@ -344,8 +344,13 @@ public class RpcApi {
      * DEPRECATED: use getBlock instead
      */
     @Deprecated
-    public Block getConfirmedBlock() throws RpcException {
-        return null;
+    public ConfirmedBlock getConfirmedBlock(int slot) throws RpcException {
+        List<Object> params = new ArrayList<Object>();
+
+        params.add(slot);
+        params.add(new ConfirmedBlockConfig());
+
+        return client.call("getConfirmedBlock", params, ConfirmedBlock.class);
     }
 
 

--- a/src/main/java/org/p2p/solanaj/rpc/types/Block.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/Block.java
@@ -1,4 +1,0 @@
-package org.p2p.solanaj.rpc.types;
-
-public class Block {
-}

--- a/src/main/java/org/p2p/solanaj/rpc/types/ConfigObjects.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/ConfigObjects.java
@@ -147,4 +147,28 @@ public class ConfigObjects {
             this.replaceRecentBlockhash = replaceRecentBlockhash;
         }
     }
+
+    public static class ConfirmedBlockConfig {
+        @Json(name = "encoding")
+        private String encoding = "json";
+        @Json(name = "transactionDetails")
+        private String transactionDetails = "full";
+        @Json(name = "rewards")
+        private Boolean rewards = true;
+        @Json(name = "commitment")
+        private String commitment = "finalized";
+
+        public ConfirmedBlockConfig() {
+        }
+
+        public ConfirmedBlockConfig(String encoding,
+                                    String transactionDetails,
+                                    Boolean rewards,
+                                    String commitment) {
+            this.encoding = encoding;
+            this.transactionDetails = transactionDetails;
+            this.rewards = rewards;
+            this.commitment = commitment;
+        }
+    }
 }

--- a/src/main/java/org/p2p/solanaj/rpc/types/ConfirmedBlock.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/ConfirmedBlock.java
@@ -1,0 +1,24 @@
+package org.p2p.solanaj.rpc.types;
+
+import com.squareup.moshi.Json;
+
+import java.util.List;
+
+public class ConfirmedBlock {
+
+    @Json(name = "blockTime")
+    private int blockTime;
+
+    @Json(name = "blockhash")
+    private String blockhash;
+
+    @Json(name = "parentSlot")
+    private int parentSlot;
+
+    @Json(name = "previousBlockhash")
+    private String previousBlockhash;
+
+    @Json(name = "transactions")
+    private List<ConfirmedTransaction> transactions;
+
+}


### PR DESCRIPTION
Added interface for getConfirmedBlock. Even though it is deprecated soon, the new endpoint has yet to be created. This is a stopgap until Solana 1.8 is released