### PR TITLE
changed order of parameters to get rpcClient.call to work

### DIFF
--- a/src/main/java/org/p2p/solanaj/rpc/RpcClient.java
+++ b/src/main/java/org/p2p/solanaj/rpc/RpcClient.java
@@ -53,7 +53,7 @@ public class RpcClient {
                 .adapter(Types.newParameterizedType(RpcResponse.class, Type.class.cast(clazz)));
 
         Request request = new Request.Builder().url(getEndpoint())
-                .post(RequestBody.create(rpcRequestJsonAdapter.toJson(rpcRequest), JSON)).build();
+                .post(RequestBody.create(JSON, rpcRequestJsonAdapter.toJson(rpcRequest))).build();
 
         try {
             Response response = httpClient.newCall(request).execute();


### PR DESCRIPTION
I tried downloading and using this library in my project. Project compiled sucesfully but when I tried using the api call, I got the error: 
```
ava.lang.NoSuchMethodError: okhttp3.RequestBody.create(Ljava/lang/String;Lokhttp3/MediaType;)Lokhttp3/RequestBody;

	at org.p2p.solanaj.rpc.RpcClient.call(RpcClient.java:56)
	at org.p2p.solanaj.rpc.RpcApi.getBalance(RpcApi.java:98)
	at org.p2p.solanaj.rpc.RpcApi.getBalance(RpcApi.java:87)
```

After investigation I found out that that temporary fix is to change the order of paramaters passed to the method `RequestBody.create(JSON, rpcRequestJsonAdapter.toJson(rpcRequest))).build()`

The method is marked as deprecated so for future it would be good idea to make a better fix. 
Issue https://github.com/skynetcapital/solanaj/issues/83 is realted to this PR