### PR TITLE
Tweaks and convenience helpers

### DIFF
--- a/src/main/java/org/p2p/solanaj/core/Transaction.java
+++ b/src/main/java/org/p2p/solanaj/core/Transaction.java
@@ -32,6 +32,10 @@ public class Transaction {
         message.setRecentBlockHash(recentBlockhash);
     }
 
+    public List<String> getSignatures() {
+        return signatures;
+    }
+
     public void sign(Account signer) {
         sign(Arrays.asList(signer));
     }

--- a/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
+++ b/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
@@ -64,7 +64,11 @@ public class RpcApi {
         transaction.setRecentBlockHash(recentBlockHash);
         transaction.sign(signers);
         byte[] serializedTransaction = transaction.serialize();
+        return sendTransaction(serializedTransaction);
+    }
 
+    public String sendTransaction(byte[] serializedTransaction)
+            throws RpcException {
         String base64Trx = Base64.getEncoder().encodeToString(serializedTransaction);
 
         List<Object> params = new ArrayList<Object>();

--- a/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
+++ b/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
@@ -461,6 +461,12 @@ public class RpcApi {
                 Commitment commitment = (Commitment) optionalParams.get("commitment");
                 blockConfig.setCommitment(commitment.getValue());
             }
+            if (optionalParams.containsKey("transactionDetails")) {
+                blockConfig.setTransactionDetails((String) optionalParams.get("transactionDetails"));
+            }
+            if (optionalParams.containsKey("rewards")) {
+                blockConfig.setRewards((Boolean) optionalParams.get("rewards"));
+            }
             params.add(blockConfig);
         }
 


### PR DESCRIPTION
This PR:

 - Splits `sendTransaction()` in two, to also accept an already serialized transaction as a byte array
 - Extends `getBlock()` to forward the `transactionDetails` and `rewards` parameters
 - Adds a `getSignatures()` method to `core.Transaction` (needed to know the txhash)